### PR TITLE
Add `MockitoDefnValToDeclVarTransformer`

### DIFF
--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
@@ -1,0 +1,19 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.captor.Captor;
+import org.mockito.captor.ArgCaptor;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Captor
+    private Captor<Foo> fooCaptor;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.scala
@@ -1,0 +1,8 @@
+package dummy
+
+import org.mockito.captor.{Captor, ArgCaptor}
+
+class SampleTest {
+
+  private val fooCaptor: Captor[Foo] = ArgCaptor[Foo]
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
@@ -1,0 +1,19 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.captor.Captor;
+import org.mockito.captor.ArgCaptor;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Captor
+    private Captor<Foo> fooCaptor;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.scala
@@ -1,0 +1,8 @@
+package dummy
+
+import org.mockito.captor.{Captor, ArgCaptor}
+
+class SampleTest {
+
+  private val fooCaptor = ArgCaptor[Foo]
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
@@ -1,0 +1,18 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Mock
+    private Foo x;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.scala
@@ -1,0 +1,7 @@
+package dummy
+
+import org.mockito.Mockito.mock
+class SampleTest {
+
+  private val x: Foo = mock[Foo]
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
@@ -1,0 +1,18 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Mock
+    private Foo x;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.scala
@@ -1,0 +1,8 @@
+package dummy
+
+import org.mockito.Mockito.mock
+
+class SampleTest {
+
+  private val x = mock[Foo]
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.java
@@ -1,0 +1,18 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Spy
+    private Foo x;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.scala
@@ -1,0 +1,8 @@
+package dummy
+
+import org.mockito.Mockito.spy
+
+class SampleTest {
+
+  private val x: Foo = spy[Foo]
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
@@ -1,0 +1,18 @@
+package dummy;
+
+import java.io.*;
+import java.lang.*;
+import java.math.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+import org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleTest {
+    @Spy
+    private Foo x;
+
+    public SampleTest() {
+    }
+}

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.scala
@@ -1,0 +1,8 @@
+package dummy
+
+import org.mockito.Mockito.spy
+
+class SampleTest {
+
+  private val x = spy[Foo]
+}

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
-import io.github.effiban.scala2java.spi.transformers.ClassTransformer
+import io.github.effiban.scala2java.spi.transformers.{ClassTransformer, DefnValToDeclVarTransformer}
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
-import io.github.effiban.scala2javaext.mockito.transformer.MockitoClassTransformer
+import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer}
 
 import scala.meta.{Source, Term}
 
@@ -19,4 +19,6 @@ class MockitoExtension extends Scala2JavaExtension {
   override def classTransformer(): ClassTransformer = MockitoClassTransformer
 
   override def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = MockitoTemplateInitExcludedPredicate
+
+  override def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = MockitoDefnValToDeclVarTransformer
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
@@ -1,0 +1,48 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+
+import scala.meta.{Decl, Defn, Mod, Term, XtensionQuasiquoteMod, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
+
+object MockitoDefnValToDeclVarTransformer extends DefnValToDeclVarTransformer {
+
+  override def transform(defnVal: Defn.Val, javaScope: JavaScope): Option[Decl.Var] = {
+    javaScope match {
+      case JavaScope.Class => transformMember(defnVal)
+      case _ => None
+    }
+  }
+
+  private def transformMember(defnVal: Defn.Val): Option[Decl.Var] = {
+    defnVal.rhs match {
+      case Term.ApplyType(q"mock", _) => transformMockOrSpyMember(defnVal, mod"@Mock")
+      case Term.ApplyType(q"spy", _) => transformMockOrSpyMember(defnVal, mod"@Spy")
+      case Term.ApplyType(q"ArgCaptor", _) => transformCaptorMember(defnVal)
+      case _ => None
+    }
+  }
+
+  private def transformMockOrSpyMember(defnVal: Defn.Val, annot: Mod.Annot): Option[Decl.Var] = {
+    import defnVal._
+
+    val newMods = annot +: mods
+    (decltpe, rhs) match {
+      case (Some(tpe), _) => Some(Decl.Var(newMods, pats, tpe))
+      case (None, Term.ApplyType(_, tpe :: Nil)) => Some(Decl.Var(newMods, pats, tpe))
+      case _ => None
+    }
+  }
+
+  private def transformCaptorMember(defnVal: Defn.Val): Option[Decl.Var] = {
+    import defnVal._
+
+    val newMods = mod"@Captor" +: mods
+    (decltpe, rhs) match {
+      case (Some(tpe), _) => Some(Decl.Var(newMods, pats, tpe))
+      case (None, Term.ApplyType(_, tpe :: Nil)) => Some(Decl.Var(newMods, pats, t"Captor[$tpe]"))
+      case _ => None
+    }
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
@@ -2,7 +2,7 @@ package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
 import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
-import io.github.effiban.scala2javaext.mockito.transformer.MockitoClassTransformer
+import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer}
 
 import scala.meta.{Source, XtensionQuasiquoteTerm}
 
@@ -74,5 +74,9 @@ class MockitoExtensionTest extends UnitTestSuite {
 
   test("templateInitExcludedPredicate() should return MockitoTemplateInitExcludedPredicate") {
     templateInitExcludedPredicate() shouldBe MockitoTemplateInitExcludedPredicate
+  }
+
+  test("defnValToDeclVarTransformer() should return MockitoDefnValToDeclVarTransformer") {
+    defnValToDeclVarTransformer() shouldBe MockitoDefnValToDeclVarTransformer
   }
 }

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
@@ -1,0 +1,82 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+import io.github.effiban.scala2javaext.mockito.transformer.MockitoDefnValToDeclVarTransformer.transform
+
+import scala.meta.XtensionQuasiquoteTerm
+
+class MockitoDefnValToDeclVarTransformerTest extends UnitTestSuite {
+
+  test("transform() for a mock in class scope with explicit type should return a 'var' annotated with '@Mock'") {
+    val defnVal = q"private val myMock: Foo = mock[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Mock
+      private var myMock: Foo
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+
+  test("transform() for a mock in class scope with an implicit type should return a 'var' annotated with '@Mock'") {
+    val defnVal = q"private val myMock = mock[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Mock
+      private var myMock: Foo
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+
+  test("transform() for a spy in class scope with explicit type should return a 'var' annotated with '@Spy'") {
+    val defnVal = q"private val mySpy: Foo = spy[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Spy
+      private var mySpy: Foo
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+
+  test("transform() for a spy in class scope with an implicit type should return a 'var' annotated with '@Spy'") {
+    val defnVal = q"private val mySpy = spy[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Spy
+      private var mySpy: Foo
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+
+  test("transform() for a captor in class scope with explicit type should return a 'var' annotated with '@Captor'") {
+    val defnVal = q"private val myCaptor: Captor[Foo] = ArgCaptor[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Captor
+      private var myCaptor: Captor[Foo]
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+
+  test("transform() for a captor in class scope with implicit type should return a 'var' annotated with '@Captor'") {
+    val defnVal = q"private val myCaptor = ArgCaptor[Foo]"
+
+    val expectedDeclVar =
+      q"""
+      @Captor
+      private var myCaptor: Captor[Foo]
+      """
+
+    transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
+  }
+}


### PR DESCRIPTION
Adding the transformer for mock/spy/captor members.
For example the following Scala code:

```scala
private val foo = mock[Foo] 
```
will be transformed to the Java code:

```java
@Mock
private Foo foo;
```