### PR TITLE
Add `MockitoDefnValTransformer`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 project.ext.scalaMajorVersion = "2.13"
-project.ext.scala2javaVersion = "2.0.2"
+project.ext.scala2javaVersion = "2.1.0"
 
 java {
     toolchain {

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
@@ -6,7 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
-import org.mockito.Mockito.mock;
+import org.mockito.MockitoSugar.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.scala
@@ -1,6 +1,6 @@
 package dummy
 
-import org.mockito.Mockito.mock
+import org.mockito.MockitoSugar.mock
 class SampleTest {
 
   private val x: Foo = mock[Foo]

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
@@ -6,7 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
-import org.mockito.Mockito.mock;
+import org.mockito.MockitoSugar.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.scala
@@ -1,6 +1,6 @@
 package dummy
 
-import org.mockito.Mockito.mock
+import org.mockito.MockitoSugar.mock
 
 class SampleTest {
 

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.java
@@ -11,7 +11,7 @@ import org.mockito.MockitoSugar.spy;
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {
     @Spy
-    private Foo x;
+    private final Foo x = new Foo(2);
 
     public SampleTest() {
     }

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.scala
@@ -4,5 +4,5 @@ import org.mockito.MockitoSugar.spy
 
 class SampleTest {
 
-  private val x: Foo = spy[Foo]
+  private val x: Foo = spy[Foo](new Foo(2))
 }

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.java
@@ -11,7 +11,7 @@ import org.mockito.MockitoSugar.spy;
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {
     @Spy
-    private Foo x;
+    private final Foo x = new Foo(2);
 
     public SampleTest() {
     }

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.scala
@@ -4,5 +4,5 @@ import org.mockito.MockitoSugar.spy
 
 class SampleTest {
 
-  private val x: Foo = spy[Foo]
+  private val x = spy[Foo](new Foo(2))
 }

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
@@ -6,7 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
-import org.mockito.Mockito.spy;
+import org.mockito.MockitoSugar.spy;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.scala
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.scala
@@ -1,6 +1,6 @@
 package dummy
 
-import org.mockito.Mockito.spy
+import org.mockito.MockitoSugar.spy
 
 class SampleTest {
 

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
@@ -2,9 +2,9 @@ package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
-import io.github.effiban.scala2java.spi.transformers.{ClassTransformer, DefnValToDeclVarTransformer}
+import io.github.effiban.scala2java.spi.transformers.{ClassTransformer, DefnValToDeclVarTransformer, DefnValTransformer}
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
-import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer}
+import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer, MockitoDefnValTransformer}
 
 import scala.meta.{Source, Term}
 
@@ -19,6 +19,9 @@ class MockitoExtension extends Scala2JavaExtension {
   override def classTransformer(): ClassTransformer = MockitoClassTransformer
 
   override def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = MockitoTemplateInitExcludedPredicate
+
+
+  override def defnValTransformer(): DefnValTransformer = MockitoDefnValTransformer
 
   override def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = MockitoDefnValToDeclVarTransformer
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/common/MockitoAnnotations.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/common/MockitoAnnotations.scala
@@ -1,0 +1,9 @@
+package io.github.effiban.scala2javaext.mockito.common
+
+import scala.meta.XtensionQuasiquoteMod
+
+object MockitoAnnotations {
+  val Mock = mod"@Mock"
+  val Spy = mod"@Spy"
+  val Captor = mod"@Captor"
+}

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
@@ -3,8 +3,9 @@ package io.github.effiban.scala2javaext.mockito.transformer
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
+import io.github.effiban.scala2javaext.mockito.common.MockitoAnnotations.{Captor, Mock, Spy}
 
-import scala.meta.{Decl, Defn, Mod, Term, XtensionQuasiquoteMod, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
+import scala.meta.{Decl, Defn, Mod, Term, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
 
 object MockitoDefnValToDeclVarTransformer extends DefnValToDeclVarTransformer {
 
@@ -17,8 +18,8 @@ object MockitoDefnValToDeclVarTransformer extends DefnValToDeclVarTransformer {
 
   private def transformMember(defnVal: Defn.Val): Option[Decl.Var] = {
     defnVal.rhs match {
-      case Term.ApplyType(q"mock", _) => transformMockOrSpyMember(defnVal, mod"@Mock")
-      case Term.ApplyType(q"spy", _) => transformMockOrSpyMember(defnVal, mod"@Spy")
+      case Term.ApplyType(q"mock", _) => transformMockOrSpyMember(defnVal, Mock)
+      case Term.ApplyType(q"spy", _) => transformMockOrSpyMember(defnVal, Spy)
       case Term.ApplyType(q"ArgCaptor", _) => transformCaptorMember(defnVal)
       case _ => None
     }
@@ -38,7 +39,7 @@ object MockitoDefnValToDeclVarTransformer extends DefnValToDeclVarTransformer {
   private def transformCaptorMember(defnVal: Defn.Val): Option[Decl.Var] = {
     import defnVal._
 
-    val newMods = mod"@Captor" +: mods
+    val newMods = Captor +: mods
     (decltpe, rhs) match {
       case (Some(tpe), _) => Some(Decl.Var(newMods, pats, tpe))
       case (None, Term.ApplyType(_, tpe :: Nil)) => Some(Decl.Var(newMods, pats, t"Captor[$tpe]"))

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValTransformer.scala
@@ -1,0 +1,33 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
+import io.github.effiban.scala2java.spi.transformers.DefnValTransformer
+import io.github.effiban.scala2javaext.mockito.common.MockitoAnnotations.Spy
+
+import scala.meta.{Defn, Term, Type, XtensionQuasiquoteTerm}
+
+object MockitoDefnValTransformer extends DefnValTransformer {
+
+  override def transform(defnVal: Defn.Val, javaScope: JavaScope): Defn.Val = {
+    javaScope match {
+      case JavaScope.Class => transformMember(defnVal)
+      case _ => defnVal
+    }
+  }
+
+  private def transformMember(defnVal: Defn.Val): Defn.Val = {
+    defnVal.rhs match {
+      case Term.Apply(Term.ApplyType(q"spy", rhsType :: Nil), initializer :: Nil) => transformSpyMember(defnVal, rhsType, initializer)
+      case _ => defnVal
+    }
+  }
+
+  private def transformSpyMember(member: Defn.Val, rhsType: Type, initializer: Term): Defn.Val = {
+    import member._
+
+    val newMods = Spy +: mods
+    val resolvedType = decltpe.getOrElse(rhsType)
+    Defn.Val(newMods, pats, Some(resolvedType), initializer)
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
@@ -2,7 +2,7 @@ package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
 import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
-import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer}
+import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer, MockitoDefnValTransformer}
 
 import scala.meta.{Source, XtensionQuasiquoteTerm}
 
@@ -74,6 +74,10 @@ class MockitoExtensionTest extends UnitTestSuite {
 
   test("templateInitExcludedPredicate() should return MockitoTemplateInitExcludedPredicate") {
     templateInitExcludedPredicate() shouldBe MockitoTemplateInitExcludedPredicate
+  }
+
+  test("defnValTransformer() should return MockitoDefnValTransformer") {
+    defnValTransformer() shouldBe MockitoDefnValTransformer
   }
 
   test("defnValToDeclVarTransformer() should return MockitoDefnValToDeclVarTransformer") {

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
@@ -79,4 +79,19 @@ class MockitoDefnValToDeclVarTransformerTest extends UnitTestSuite {
 
     transform(defnVal, JavaScope.Class).value.structure shouldBe expectedDeclVar.structure
   }
+
+  test("transform() for a mock in block scope should return None") {
+    val defnVal = q"private val foo = mock[Foo]"
+    transform(defnVal, JavaScope.Block) shouldBe None
+  }
+
+  test("transform() for a spy in block scope should return None") {
+    val defnVal = q"private val foo = spy[Foo]"
+    transform(defnVal, JavaScope.Block) shouldBe None
+  }
+
+  test("transform() for a captor in block scope should return None") {
+    val defnVal = q"private val myCaptor = ArgCaptor[Foo]"
+    transform(defnVal, JavaScope.Block) shouldBe None
+  }
 }

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValTransformerTest.scala
@@ -1,0 +1,46 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.entities.JavaScope
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+import io.github.effiban.scala2javaext.mockito.transformer.MockitoDefnValTransformer.transform
+
+import scala.meta.XtensionQuasiquoteTerm
+
+class MockitoDefnValTransformerTest extends UnitTestSuite {
+
+  test("transform() for a spy in class scope with explicit type and initializer, should add the '@Spy' annotation") {
+    val inputDefnVal = q"private val mySpy: Foo = spy[Foo](new Foo(2))"
+
+    val expectedOutputDefnVal =
+      q"""
+      @Spy
+      private val mySpy: Foo = new Foo(2)
+      """
+
+    transform(inputDefnVal, JavaScope.Class).structure shouldBe expectedOutputDefnVal.structure
+  }
+
+  test("transform() for a spy in class scope with an implicit type should add the type and the '@Spy' annotation") {
+    val inputDefnVal = q"private val mySpy = spy[Foo](new Foo(2))"
+
+    val expectedOutputDefnVal =
+      q"""
+      @Spy
+      private val mySpy: Foo = new Foo(2)
+      """
+
+    transform(inputDefnVal, JavaScope.Class).structure shouldBe expectedOutputDefnVal.structure
+  }
+
+  test("transform() for a spy in block scope should return unchanged") {
+    val defnVal = q"private val mySpy = spy[Foo](new Foo(2))"
+
+    transform(defnVal, JavaScope.Block).structure shouldBe defnVal.structure
+  }
+
+  test("transform() for a mock in class scope should return unchanged") {
+    val defnVal = q"private val myMock = mock[Foo]"
+
+    transform(defnVal, JavaScope.Class).structure shouldBe defnVal.structure
+  }
+}


### PR DESCRIPTION
Adding a transformer for `Defn.Val`-s to cover the specific case of an initialized Spy member.
For example, the following Scala code:
```scala
private val foo = spy[Foo](new Foo(2))
```
will be translated into the Java code:
```java
@Spy
private final Foo foo = new Foo(2);
```