### PR TITLE
Add `MockitoAdditionalImportersProvider`

### DIFF
--- a/src/integrationTest/resources/testfiles/Class/Basic/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/Class/Basic/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.Mock;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/Class/Importing/ArgumentMatchersSugar/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/Class/Importing/ArgumentMatchersSugar/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/Class/Importing/MockitoSugar/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/Class/Importing/MockitoSugar/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/Class/ImportingAndExtending/ArgumentMatchersSugar/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/Class/ImportingAndExtending/ArgumentMatchersSugar/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/Class/ImportingAndExtending/MockitoSugar/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/Class/ImportingAndExtending/MockitoSugar/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.captor.Captor;
 import org.mockito.captor.ArgCaptor;
 

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.captor.Captor;
 import org.mockito.captor.ArgCaptor;
 

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithExplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.mock;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/mock/WithImplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.mock;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithExplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.spy;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/Initialized/WithImplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.spy;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithExplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.spy;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/spy/NotInitialized/WithImplicitType/SampleTest.java
@@ -6,6 +6,7 @@ import java.math.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
+import org.mockito.*;
 import org.mockito.MockitoSugar.spy;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
@@ -2,8 +2,10 @@ package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
 import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
+import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
 import io.github.effiban.scala2java.spi.transformers.{ClassTransformer, DefnValToDeclVarTransformer, DefnValTransformer}
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
+import io.github.effiban.scala2javaext.mockito.providers.MockitoAdditionalImportersProvider
 import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer, MockitoDefnValTransformer}
 
 import scala.meta.{Source, Term}
@@ -14,12 +16,14 @@ class MockitoExtension extends Scala2JavaExtension {
     case mockitoQualifier@Term.Select(Term.Name("org"), Term.Name("mockito")) => mockitoQualifier
   }.nonEmpty
 
+
+  override def additionalImportersProvider(): AdditionalImportersProvider = MockitoAdditionalImportersProvider
+
   override def importerExcludedPredicate(): ImporterExcludedPredicate = MockitoImporterExcludedPredicate
 
   override def classTransformer(): ClassTransformer = MockitoClassTransformer
 
   override def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = MockitoTemplateInitExcludedPredicate
-
 
   override def defnValTransformer(): DefnValTransformer = MockitoDefnValTransformer
 

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoAdditionalImportersProvider.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoAdditionalImportersProvider.scala
@@ -1,0 +1,9 @@
+package io.github.effiban.scala2javaext.mockito.providers
+
+import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
+
+import scala.meta.{Importer, XtensionQuasiquoteImporter}
+
+object MockitoAdditionalImportersProvider extends AdditionalImportersProvider {
+  override def provide(): List[Importer] = List(importer"org.mockito._")
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
@@ -1,6 +1,7 @@
 package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
+import io.github.effiban.scala2javaext.mockito.providers.MockitoAdditionalImportersProvider
 import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
 import io.github.effiban.scala2javaext.mockito.transformer.{MockitoClassTransformer, MockitoDefnValToDeclVarTransformer, MockitoDefnValTransformer}
 
@@ -62,6 +63,10 @@ class MockitoExtensionTest extends UnitTestSuite {
       q"import foo2.bar2"
     ))
     shouldBeAppliedTo(source) shouldBe false
+  }
+
+  test("additionalImportersProvider() should return MockitoAdditionalImportersProvider") {
+    additionalImportersProvider() shouldBe MockitoAdditionalImportersProvider
   }
 
   test("importerExcludedPredicate() should return MockitoImporterExcludedPredicate") {

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoAdditionalImportersProviderTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoAdditionalImportersProviderTest.scala
@@ -1,0 +1,13 @@
+package io.github.effiban.scala2javaext.mockito.providers
+
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+
+import scala.meta.XtensionQuasiquoteImporter
+
+class MockitoAdditionalImportersProviderTest extends UnitTestSuite {
+
+  test("provide() should return the import of 'org.mockito._'") {
+    MockitoAdditionalImportersProvider.provide().structure shouldBe List(importer"org.mockito._").structure
+  }
+
+}


### PR DESCRIPTION
Adding `import org.mockito.*` by default to the output Java file, to cover the main imported types in Java that are not used in Scala such as the **annotation** `org.mockito.Mock` (not precise and may not compile).