### PR TITLE
Add `MockitoTypeNameTransformer`

### DIFF
--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithExplicitType/SampleTest.java
@@ -13,7 +13,7 @@ import org.mockito.captor.ArgCaptor;
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {
     @Captor
-    private Captor<Foo> fooCaptor;
+    private ArgumentCaptor<Foo> fooCaptor;
 
     public SampleTest() {
     }

--- a/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InClass/ArgCaptor/WithImplicitType/SampleTest.java
@@ -13,7 +13,7 @@ import org.mockito.captor.ArgCaptor;
 @RunWith(MockitoJUnitRunner.class)
 public class SampleTest {
     @Captor
-    private Captor<Foo> fooCaptor;
+    private ArgumentCaptor<Foo> fooCaptor;
 
     public SampleTest() {
     }

--- a/src/integrationTest/resources/testfiles/DefnVal/InMethod/ArgCaptor/WithExplicitType/SampleTest.java
+++ b/src/integrationTest/resources/testfiles/DefnVal/InMethod/ArgCaptor/WithExplicitType/SampleTest.java
@@ -17,6 +17,6 @@ public class SampleTest {
     }
 
     public void aMethod() {
-        final Captor<Foo> fooCaptor = ArgCaptor(Foo.class);
+        final ArgumentCaptor<Foo> fooCaptor = ArgCaptor(Foo.class);
     }
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
@@ -30,4 +30,6 @@ class MockitoExtension extends Scala2JavaExtension {
   override def termApplyTypeToTermApplyTransformer(): TermApplyTypeToTermApplyTransformer = MockitoTermApplyTypeToTermApplyTransformer
 
   override def termSelectTransformer(): TermSelectTransformer = MockitoTermSelectTransformer
+
+  override def typeNameTransformer(): TypeNameTransformer = MockitoTypeNameTransfomer
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/common/MockitoAnnotations.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/common/MockitoAnnotations.scala
@@ -6,4 +6,6 @@ object MockitoAnnotations {
   val Mock = mod"@Mock"
   val Spy = mod"@Spy"
   val Captor = mod"@Captor"
+  /** A temporary synthetic annotation to avoid clashing with the Scala 'Captor' type until all transformations are complete  */
+  val JavaCaptor = mod"@JavaCaptor"
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformer.scala
@@ -3,7 +3,7 @@ package io.github.effiban.scala2javaext.mockito.transformer
 import io.github.effiban.scala2java.spi.entities.JavaScope
 import io.github.effiban.scala2java.spi.entities.JavaScope.JavaScope
 import io.github.effiban.scala2java.spi.transformers.DefnValToDeclVarTransformer
-import io.github.effiban.scala2javaext.mockito.common.MockitoAnnotations.{Captor, Mock, Spy}
+import io.github.effiban.scala2javaext.mockito.common.MockitoAnnotations.{Captor, JavaCaptor, Mock, Spy}
 
 import scala.meta.{Decl, Defn, Mod, Term, XtensionQuasiquoteTerm, XtensionQuasiquoteType}
 
@@ -39,7 +39,7 @@ object MockitoDefnValToDeclVarTransformer extends DefnValToDeclVarTransformer {
   private def transformCaptorMember(defnVal: Defn.Val): Option[Decl.Var] = {
     import defnVal._
 
-    val newMods = Captor +: mods
+    val newMods = JavaCaptor +: mods
     (decltpe, rhs) match {
       case (Some(tpe), _) => Some(Decl.Var(newMods, pats, tpe))
       case (None, Term.ApplyType(_, tpe :: Nil)) => Some(Decl.Var(newMods, pats, t"Captor[$tpe]"))

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTypeNameTransfomer.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTypeNameTransfomer.scala
@@ -1,0 +1,17 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.transformers.TypeNameTransformer
+
+import scala.meta.Type
+import scala.meta.XtensionQuasiquoteType
+
+object MockitoTypeNameTransfomer extends TypeNameTransformer {
+
+  override def transform(typeName: Type.Name): Type.Name = {
+    typeName match {
+      case t"Captor" => t"ArgumentCaptor"
+      case t"JavaCaptor" => t"Captor"
+      case aTypeName => aTypeName
+    }
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoDefnValToDeclVarTransformerTest.scala
@@ -61,7 +61,7 @@ class MockitoDefnValToDeclVarTransformerTest extends UnitTestSuite {
 
     val expectedDeclVar =
       q"""
-      @Captor
+      @JavaCaptor
       private var myCaptor: Captor[Foo]
       """
 
@@ -73,7 +73,7 @@ class MockitoDefnValToDeclVarTransformerTest extends UnitTestSuite {
 
     val expectedDeclVar =
       q"""
-      @Captor
+      @JavaCaptor
       private var myCaptor: Captor[Foo]
       """
 

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTypeNameTransfomerTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTypeNameTransfomerTest.scala
@@ -1,0 +1,23 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+import io.github.effiban.scala2javaext.mockito.transformer.MockitoTypeNameTransfomer.transform
+
+import scala.meta.{Type, XtensionQuasiquoteType}
+
+class MockitoTypeNameTransfomerTest extends UnitTestSuite {
+
+  private val Scenarios = Table(
+    ("Input", "ExpectedOutput"),
+    (t"Captor", t"ArgumentCaptor"),
+    (t"JavaCaptor", t"Captor"),
+    (t"AAA", t"AAA")
+  )
+
+  forAll(Scenarios) {
+    (input: Type.Name, expectedOutput: Type.Name) =>
+      test(s"$input should be transformed to $expectedOutput") {
+        transform(input).structure shouldBe expectedOutput.structure
+      }
+  }
+}


### PR DESCRIPTION
Currently needed only for transforming the Scala `Captor` type to Java `ArgumentCaptor`.
Note that In addition, due to the order of transformer invocation - we need to avoid a clash between the Java `@Captor` and Scala `Captor`, so a temporary annotation `@JavaCaptor` is introduced as the output of the first transformer (`MockitoDefnValToDeclVarTransformer`)