### PR TITLE
Split `MockitoExtension` into traits

### DIFF
--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/MockitoExtension.scala
@@ -1,39 +1,17 @@
 package io.github.effiban.scala2javaext.mockito
 
 import io.github.effiban.scala2java.spi.Scala2JavaExtension
-import io.github.effiban.scala2java.spi.predicates.{ImporterExcludedPredicate, TemplateInitExcludedPredicate}
-import io.github.effiban.scala2java.spi.providers.AdditionalImportersProvider
-import io.github.effiban.scala2java.spi.transformers._
-import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
-import io.github.effiban.scala2javaext.mockito.providers.MockitoAdditionalImportersProvider
+import io.github.effiban.scala2javaext.mockito.predicate.MockitoPredicates
+import io.github.effiban.scala2javaext.mockito.providers.MockitoProviders
 import io.github.effiban.scala2javaext.mockito.transformer._
 
 import scala.meta.{Term, XtensionQuasiquoteTerm}
 
-class MockitoExtension extends Scala2JavaExtension {
+class MockitoExtension extends Scala2JavaExtension
+  with MockitoPredicates
+  with MockitoProviders
+  with MockitoTransformers {
 
   override def shouldBeAppliedIfContains(termSelect: Term.Select): Boolean =
     q"org.mockito".structure == termSelect.structure
-
-  override def additionalImportersProvider(): AdditionalImportersProvider = MockitoAdditionalImportersProvider
-
-  override def importerExcludedPredicate(): ImporterExcludedPredicate = MockitoImporterExcludedPredicate
-
-  override def importerTransformer(): ImporterTransformer = MockitoImporterTransformer
-
-  override def classTransformer(): ClassTransformer = MockitoClassTransformer
-
-  override def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = MockitoTemplateInitExcludedPredicate
-
-  override def defnValTransformer(): DefnValTransformer = MockitoDefnValTransformer
-
-  override def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = MockitoDefnValToDeclVarTransformer
-
-  override def termApplyTypeToTermApplyTransformer(): TermApplyTypeToTermApplyTransformer = MockitoTermApplyTypeToTermApplyTransformer
-
-  override def termApplyTransformer(): TermApplyTransformer = MockitoTermApplyTransformer
-
-  override def termSelectTransformer(): TermSelectTransformer = MockitoTermSelectTransformer
-
-  override def typeNameTransformer(): TypeNameTransformer = MockitoTypeNameTransfomer
 }

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/predicate/MockitoPredicates.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/predicate/MockitoPredicates.scala
@@ -1,0 +1,10 @@
+package io.github.effiban.scala2javaext.mockito.predicate
+
+import io.github.effiban.scala2java.spi.predicates.{ExtendedPredicates, ImporterExcludedPredicate, TemplateInitExcludedPredicate}
+
+trait MockitoPredicates extends ExtendedPredicates {
+
+  override def importerExcludedPredicate(): ImporterExcludedPredicate = MockitoImporterExcludedPredicate
+
+  override def templateInitExcludedPredicate(): TemplateInitExcludedPredicate = MockitoTemplateInitExcludedPredicate
+}

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoProviders.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoProviders.scala
@@ -1,0 +1,8 @@
+package io.github.effiban.scala2javaext.mockito.providers
+
+import io.github.effiban.scala2java.spi.providers.{AdditionalImportersProvider, ExtendedProviders}
+
+trait MockitoProviders extends ExtendedProviders {
+
+  override def additionalImportersProvider(): AdditionalImportersProvider = MockitoAdditionalImportersProvider
+}

--- a/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTransformers.scala
+++ b/src/main/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTransformers.scala
@@ -1,0 +1,22 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2java.spi.transformers._
+
+trait MockitoTransformers extends ExtendedTransformers {
+
+  override def importerTransformer(): ImporterTransformer = MockitoImporterTransformer
+
+  override def classTransformer(): ClassTransformer = MockitoClassTransformer
+
+  override def defnValTransformer(): DefnValTransformer = MockitoDefnValTransformer
+
+  override def defnValToDeclVarTransformer(): DefnValToDeclVarTransformer = MockitoDefnValToDeclVarTransformer
+
+  override def termApplyTypeToTermApplyTransformer(): TermApplyTypeToTermApplyTransformer = MockitoTermApplyTypeToTermApplyTransformer
+
+  override def termApplyTransformer(): TermApplyTransformer = MockitoTermApplyTransformer
+
+  override def termSelectTransformer(): TermSelectTransformer = MockitoTermSelectTransformer
+
+  override def typeNameTransformer(): TypeNameTransformer = MockitoTypeNameTransfomer
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/MockitoExtensionTest.scala
@@ -1,9 +1,6 @@
 package io.github.effiban.scala2javaext.mockito
 
-import io.github.effiban.scala2javaext.mockito.predicate.{MockitoImporterExcludedPredicate, MockitoTemplateInitExcludedPredicate}
-import io.github.effiban.scala2javaext.mockito.providers.MockitoAdditionalImportersProvider
 import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
-import io.github.effiban.scala2javaext.mockito.transformer._
 
 import scala.meta.XtensionQuasiquoteTerm
 
@@ -18,45 +15,5 @@ class MockitoExtensionTest extends UnitTestSuite {
 
   test("shouldBeAppliedIfContains() for a non-mockito qualified name should return false") {
     shouldBeAppliedIfContains(q"org.othermock") shouldBe false
-  }
-
-  test("additionalImportersProvider() should return MockitoAdditionalImportersProvider") {
-    additionalImportersProvider() shouldBe MockitoAdditionalImportersProvider
-  }
-
-  test("importerExcludedPredicate() should return MockitoImporterExcludedPredicate") {
-    importerExcludedPredicate() shouldBe MockitoImporterExcludedPredicate
-  }
-
-  test("importerTransformer() should return MockitoImporterTransformer") {
-    importerTransformer() shouldBe MockitoImporterTransformer
-  }
-
-  test("classTransformer() should return MockitoClassTransformer") {
-    classTransformer() shouldBe MockitoClassTransformer
-  }
-
-  test("templateInitExcludedPredicate() should return MockitoTemplateInitExcludedPredicate") {
-    templateInitExcludedPredicate() shouldBe MockitoTemplateInitExcludedPredicate
-  }
-
-  test("defnValTransformer() should return MockitoDefnValTransformer") {
-    defnValTransformer() shouldBe MockitoDefnValTransformer
-  }
-
-  test("defnValToDeclVarTransformer() should return MockitoDefnValToDeclVarTransformer") {
-    defnValToDeclVarTransformer() shouldBe MockitoDefnValToDeclVarTransformer
-  }
-
-  test("termApplyTypeToTermApplyTransformer() should return MockitoTermApplyTypeToTermApplyTransformer") {
-    termApplyTypeToTermApplyTransformer() shouldBe MockitoTermApplyTypeToTermApplyTransformer
-  }
-
-  test("termApplyTransformer() should return MockitoTermApplyTransformer") {
-    termApplyTransformer() shouldBe MockitoTermApplyTransformer
-  }
-
-  test("termSelectTransformer() should return MockitoTermSelectTransformer") {
-    termSelectTransformer() shouldBe MockitoTermSelectTransformer
   }
 }

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/predicate/MockitoPredicatesTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/predicate/MockitoPredicatesTest.scala
@@ -1,0 +1,17 @@
+package io.github.effiban.scala2javaext.mockito.predicate
+
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+
+class MockitoPredicatesTest extends UnitTestSuite {
+
+  private val mockitoPredicates = new MockitoPredicates {}
+  import mockitoPredicates._
+
+  test("importerExcludedPredicate() should return MockitoImporterExcludedPredicate") {
+    importerExcludedPredicate() shouldBe MockitoImporterExcludedPredicate
+  }
+
+  test("templateInitExcludedPredicate() should return MockitoTemplateInitExcludedPredicate") {
+    templateInitExcludedPredicate() shouldBe MockitoTemplateInitExcludedPredicate
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoProvidersTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/providers/MockitoProvidersTest.scala
@@ -1,0 +1,13 @@
+package io.github.effiban.scala2javaext.mockito.providers
+
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+
+class MockitoProvidersTest extends UnitTestSuite {
+
+  private val mockitoProviders = new MockitoProviders {}
+  import mockitoProviders._
+
+  test("additionalImportersProvider() should return MockitoAdditionalImportersProvider") {
+    additionalImportersProvider() shouldBe MockitoAdditionalImportersProvider
+  }
+}

--- a/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTransformersTest.scala
+++ b/src/test/scala/io/github/effiban/scala2javaext/mockito/transformer/MockitoTransformersTest.scala
@@ -1,0 +1,37 @@
+package io.github.effiban.scala2javaext.mockito.transformer
+
+import io.github.effiban.scala2javaext.mockito.testsuites.UnitTestSuite
+
+class MockitoTransformersTest extends UnitTestSuite {
+
+  private val mockitoTransformers = new MockitoTransformers {}
+  import mockitoTransformers._
+
+  test("importerTransformer() should return MockitoImporterTransformer") {
+    importerTransformer() shouldBe MockitoImporterTransformer
+  }
+
+  test("classTransformer() should return MockitoClassTransformer") {
+    classTransformer() shouldBe MockitoClassTransformer
+  }
+
+  test("defnValTransformer() should return MockitoDefnValTransformer") {
+    defnValTransformer() shouldBe MockitoDefnValTransformer
+  }
+
+  test("defnValToDeclVarTransformer() should return MockitoDefnValToDeclVarTransformer") {
+    defnValToDeclVarTransformer() shouldBe MockitoDefnValToDeclVarTransformer
+  }
+
+  test("termApplyTypeToTermApplyTransformer() should return MockitoTermApplyTypeToTermApplyTransformer") {
+    termApplyTypeToTermApplyTransformer() shouldBe MockitoTermApplyTypeToTermApplyTransformer
+  }
+
+  test("termApplyTransformer() should return MockitoTermApplyTransformer") {
+    termApplyTransformer() shouldBe MockitoTermApplyTransformer
+  }
+
+  test("termSelectTransformer() should return MockitoTermSelectTransformer") {
+    termSelectTransformer() shouldBe MockitoTermSelectTransformer
+  }
+}


### PR DESCRIPTION
Split `MockitoExtension` into traits in the same structure as the base extension trait `Scala2JavaExtension`